### PR TITLE
support xdebug when replay and some file rollback to old version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 * KOALA_OUTBOUND_ADDR: ip:port, the address all outgoing traffic will be redirected to
 * KOALA_LOG_FILE: STDOUT/STDERR/filepath, if using filepath, the log will rotate every hour
 * KOALA_LOG_LEVEL: TRACE/DEBUG/INFO/ERROR/FATAL
+* KOALA_INBOUND_READ_TIMEOUT: a duration string, set the timeout of inbound read response fron sut
+* KOALA_XDEBUG_PORT: port, the port of xdebug remote port, when replay a session with xdebug
+
 
 # Build tags
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * KOALA_LOG_FILE: STDOUT/STDERR/filepath, if using filepath, the log will rotate every hour
 * KOALA_LOG_LEVEL: TRACE/DEBUG/INFO/ERROR/FATAL
 * KOALA_INBOUND_READ_TIMEOUT: a duration string, set the timeout of inbound read response fron sut
-* KOALA_XDEBUG_PORT: port, the port of xdebug remote port, when replay a session with xdebug
+* KOALA_OUTBOUND_BYPASS_PORT: port, the port of outbound will bypass, eg replay a session with xdebug and pass xdebug remote port
 
 
 # Build tags

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,3 @@ esac
 export CGO_CFLAGS="-DKOALA_LIBC_NETWORK_HOOK -DKOALA_LIBC_FILE_HOOK -DKOALA_LIBC_TIME_HOOK -DKOALA_LIBC_PATH_HOOK"
 export CGO_CPPFLAGS=$CGO_CFLAGS
 go build -tags="koala_replayer" -buildmode=c-shared -o output/koala-replayer.so github.com/v2pro/koala/cmd/replayer
-
-cp output/koala-replayer.so ~/DiDiCode/Midi/res/replayer/koala-replayer.so
-rm -rf /tmp/nuwa_dev/replayer/koala-replayer.so

--- a/build.sh
+++ b/build.sh
@@ -31,3 +31,6 @@ esac
 export CGO_CFLAGS="-DKOALA_LIBC_NETWORK_HOOK -DKOALA_LIBC_FILE_HOOK -DKOALA_LIBC_TIME_HOOK -DKOALA_LIBC_PATH_HOOK"
 export CGO_CPPFLAGS=$CGO_CFLAGS
 go build -tags="koala_replayer" -buildmode=c-shared -o output/koala-replayer.so github.com/v2pro/koala/cmd/replayer
+
+cp output/koala-replayer.so ~/DiDiCode/Midi/res/replayer/koala-replayer.so
+rm -rf /tmp/nuwa_dev/replayer/koala-replayer.so

--- a/envarg/envarg.go
+++ b/envarg/envarg.go
@@ -24,7 +24,7 @@ var outboundBypassPort int
 func init() {
 	initInboundAddr()
 	initOutboundAddr()
-	initOutboundByPassPort()
+	initOutboundBypassPort()
 	initSutAddr()
 	logFile = GetenvFromC("KOALA_LOG_FILE")
 	if logFile == "" {
@@ -98,7 +98,7 @@ func initSutAddr() {
 	sutAddr = addr
 }
 
-func initOutboundByPassPort() {
+func initOutboundBypassPort() {
 	if !isReplaying {
 		return
 	}

--- a/envarg/setup.go
+++ b/envarg/setup.go
@@ -3,47 +3,27 @@ package envarg
 import (
 	"os"
 	"github.com/v2pro/plz/countlog"
-	"github.com/v2pro/plz/countlog/output/hrf"
-	"github.com/v2pro/plz/countlog/output"
-	"github.com/v2pro/plz/countlog/output/compact"
-	"io"
-	"github.com/v2pro/plz/countlog/spi"
 )
 
 func SetupLogging() {
-	countlog.SetMinLevel(LogLevel())
-	countlog.EventWriter = output.NewEventWriter(output.EventWriterConfig{
-		Format: createLogFormat(),
-		Writer: openLogFile(),
-	})
-}
-
-func openLogFile() io.Writer {
-	fileName := LogFile()
-	switch fileName {
-	case "STDOUT":
-		return os.Stdout
-	case "STDERR":
-		return os.Stderr
-	default:
-		file, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-		if err != nil {
-			spi.OnError(err)
-			return os.Stderr
-		}
-		return file
-	}
-}
-
-func createLogFormat() output.Format {
+	logWriter := countlog.NewAsyncLogWriter(
+		LogLevel(),
+		countlog.NewFileLogOutput(LogFile()))
 	switch LogFormat() {
 	case "HumanReadableFormat":
-		return &hrf.Format{}
+		logWriter.LogFormatter = &countlog.HumanReadableFormat{
+			ContextPropertyNames: []string{"threadID", "outboundSrc"},
+			StringLengthCap:      512,
+		}
 	case "CompactFormat":
-		return &compact.Format{}
+		logWriter.LogFormatter = &countlog.CompactFormat{StringLengthCap: 512}
 	default:
 		os.Stderr.WriteString("unknown LogFormat: " + LogFormat() + "\n")
 		os.Stderr.Sync()
-		return &compact.Format{}
+		logWriter.LogFormatter = &countlog.CompactFormat{}
 	}
+	logWriter.EventWhitelist["event!replaying.talks_scored"] = true
+	//logWriter.EventWhitelist["event!sut.opening_file"] = true
+	logWriter.Start()
+	countlog.LogWriters = append(countlog.LogWriters, logWriter)
 }

--- a/gateway/gw4libc/main.go
+++ b/gateway/gw4libc/main.go
@@ -58,7 +58,10 @@ func on_connect(threadID C.pid_t, socketFD C.int, remoteAddr *C.struct_sockaddr_
 		IP:   ch.Int2ip(sockaddr_in_sin_addr_get(remoteAddr)),
 		Port: int(ch.Ntohs(sockaddr_in_sin_port_get(remoteAddr))),
 	}
-	if origAddr.String() == "127.0.0.1:18500" {
+	if origAddr.String() == "127.0.0.1:18500" || (envarg.EnableXdebug() && origAddr.Port == envarg.XdebugPort()) {
+		sut.OperateThread(sut.ThreadID(threadID), func(thread *sut.Thread) {
+			thread.IgnoreSocketFD(sut.SocketFD(socketFD), origAddr)
+		})
 		return
 	}
 	sut.OperateThread(sut.ThreadID(threadID), func(thread *sut.Thread) {

--- a/gateway/gw4libc/main.go
+++ b/gateway/gw4libc/main.go
@@ -58,7 +58,7 @@ func on_connect(threadID C.pid_t, socketFD C.int, remoteAddr *C.struct_sockaddr_
 		IP:   ch.Int2ip(sockaddr_in_sin_addr_get(remoteAddr)),
 		Port: int(ch.Ntohs(sockaddr_in_sin_port_get(remoteAddr))),
 	}
-	if origAddr.String() == "127.0.0.1:18500" || (envarg.EnableXdebug() && origAddr.Port == envarg.XdebugPort()) {
+	if origAddr.String() == "127.0.0.1:18500" || (envarg.IsReplaying() && origAddr.Port == envarg.OutboundBypassPort()) {
 		sut.OperateThread(sut.ThreadID(threadID), func(thread *sut.Thread) {
 			thread.IgnoreSocketFD(sut.SocketFD(socketFD), origAddr)
 		})

--- a/recording/async.go
+++ b/recording/async.go
@@ -24,7 +24,13 @@ func (recorder *AsyncRecorder) Start() {
 
 func (recorder *AsyncRecorder) backgroundRecord() {
 	defer func() {
-		countlog.LogPanic(recover())
+		recovered := recover()
+		if recovered != nil {
+			countlog.Error("event!recording.panic",
+				"err", recovered,
+				"ctx", recorder.Context,
+				"stacktrace", countlog.ProvideStacktrace)
+		}
 	}()
 	for {
 		session := <-recorder.recordChan

--- a/sut/state.go
+++ b/sut/state.go
@@ -1,13 +1,13 @@
 package sut
 
 import (
-	"sync"
 	"context"
-	"github.com/v2pro/koala/recording"
 	"github.com/v2pro/koala/envarg"
+	"github.com/v2pro/koala/recording"
 	"github.com/v2pro/plz/countlog"
-	"time"
 	"strconv"
+	"sync"
+	"time"
 )
 
 type SocketFD int
@@ -137,6 +137,7 @@ func newThread(threadID ThreadID) *Thread {
 		socks:          map[SocketFD]*socket{},
 		files:          map[FileFD]*file{},
 		lastAccessedAt: time.Now(),
+		ignoreSocks:    map[SocketFD]bool{},
 	}
 	if envarg.IsRecording() {
 		thread.recordingSession = recording.NewSession(int32(threadID))


### PR DESCRIPTION
1、支持指定端口，在访问 outbound 时 bypass，譬如支持 xdebug remote port 调试。
2、支持设置 inbound 在读取 sut 数据包的超时，原因是在 xdebug 的时候，很容易超时，导致回放失败。
 3、envarg/setup.go，recording/async.go 这两个文件回滚到上一个版本，否则主干编译失败
4、线程新增 ignoreSocks 属性，记录需要被忽略的 socket，目的是防止这部分包在 send/recv...，被记录成 unknown 流量