### PR TITLE
支持设置 gc global status 超时、调整 outbound 超时、增加部分日志

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * KOALA_LOG_LEVEL: TRACE/DEBUG/INFO/ERROR/FATAL
 * KOALA_INBOUND_READ_TIMEOUT: a duration string, set the timeout of inbound read response from sut
 * KOALA_OUTBOUND_BYPASS_PORT: port, the port of outbound will bypass, eg replay a session with xdebug and pass xdebug remote port
-
+* KOALA_GC_GLOBAL_STATUS_TIMEOUT: a duration string, set the timeout of gc for koala global status, eg thread, socket
 
 # Build tags
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * KOALA_OUTBOUND_ADDR: ip:port, the address all outgoing traffic will be redirected to
 * KOALA_LOG_FILE: STDOUT/STDERR/filepath, if using filepath, the log will rotate every hour
 * KOALA_LOG_LEVEL: TRACE/DEBUG/INFO/ERROR/FATAL
-* KOALA_INBOUND_READ_TIMEOUT: a duration string, set the timeout of inbound read response fron sut
+* KOALA_INBOUND_READ_TIMEOUT: a duration string, set the timeout of inbound read response from sut
 * KOALA_OUTBOUND_BYPASS_PORT: port, the port of outbound will bypass, eg replay a session with xdebug and pass xdebug remote port
 
 

--- a/envarg/envarg.go
+++ b/envarg/envarg.go
@@ -20,6 +20,7 @@ var logFile string
 var logLevel = countlog.LevelDebug
 var logFormat string
 var outboundBypassPort int
+var gcGlobalStatusTimeout = 5 * time.Second
 
 func init() {
 	initInboundAddr()
@@ -35,6 +36,16 @@ func init() {
 	if logFormat == "" {
 		logFormat = "HumanReadableFormat"
 	}
+	initGcGlobalStatusTimeout()
+	countlog.Trace("event!koala.envarg_init",
+		"logLevel", logLevel,
+		"logFile", logFile,
+		"logFormat", logFormat,
+		"inboundReadTimeout", inboundReadTimeout,
+		"outboundBypassPort", outboundBypassPort,
+		"isReplaying", IsReplaying(),
+		"isRecording", IsRecording(),
+		"isTracing", IsTracing())
 }
 
 func initLogLevel() {
@@ -111,6 +122,15 @@ func initOutboundBypassPort() {
 	}
 }
 
+func initGcGlobalStatusTimeout() {
+	timeoutStr := GetenvFromC("KOALA_GC_GLOBAL_STATUS_TIMEOUT")
+	if timeoutStr != "" {
+		if timeout, err := time.ParseDuration(timeoutStr); err == nil {
+			gcGlobalStatusTimeout = timeout
+		}
+	}
+}
+
 func IsReplaying() bool {
 	return isReplaying
 }
@@ -153,6 +173,10 @@ func LogFormat() string {
 
 func OutboundBypassPort() int {
 	return outboundBypassPort
+}
+
+func GcGlobalStatusTimeout() time.Duration {
+	return gcGlobalStatusTimeout
 }
 
 // GetenvFromC to make getenv work in php-fpm child process

--- a/outbound/outbound.go
+++ b/outbound/outbound.go
@@ -2,14 +2,15 @@ package outbound
 
 import (
 	"context"
+	"io"
+	"net"
+	"time"
+
 	"github.com/v2pro/koala/envarg"
 	"github.com/v2pro/koala/internal"
 	"github.com/v2pro/koala/recording"
 	"github.com/v2pro/koala/replaying"
 	"github.com/v2pro/plz/countlog"
-	"io"
-	"net"
-	"time"
 )
 
 const fakeIndexNotMatched = -1

--- a/replaying/replaying_match.go
+++ b/replaying/replaying_match.go
@@ -74,7 +74,6 @@ func (replayingSession *ReplayingSession) MatchOutboundTalk(
 		}
 	}
 	return maxScoreIndex, mark, replayingSession.CallOutbounds[maxScoreIndex]
-
 }
 
 func (replayingSession *ReplayingSession) loadKeys() [][]byte {

--- a/replaying/replaying_match.go
+++ b/replaying/replaying_match.go
@@ -1,12 +1,13 @@
 package replaying
 
 import (
-	"github.com/v2pro/koala/recording"
-	"github.com/v2pro/plz/countlog"
-	"context"
 	"bytes"
+	"context"
 	"fmt"
 	"math"
+
+	"github.com/v2pro/koala/recording"
+	"github.com/v2pro/plz/countlog"
 )
 
 var expect100 = []byte("Expect: 100-continue")
@@ -52,6 +53,8 @@ func (replayingSession *ReplayingSession) MatchOutboundTalk(
 	countlog.Trace("event!replaying.talks_scored",
 		"ctx", ctx,
 		"lastMatchedIndex", lastMatchedIndex,
+		"maxScoreIndex", maxScoreIndex,
+		"maxScore", maxScore,
 		"totalScore", len(chunks),
 		"scores", func() interface{} {
 			return fmt.Sprintf("%v", scores)
@@ -104,7 +107,7 @@ func cutToChunks(key []byte, unit int) [][]byte {
 		}
 	}
 	chunkCount := len(key) / unit
-	for i := 0; i < len(key)/unit; i++ {
+	for i := 0; i < chunkCount; i++ {
 		chunks = append(chunks, key[i*unit:(i+1)*unit])
 	}
 	lastChunk := key[chunkCount*unit:]
@@ -128,5 +131,5 @@ func findReadableChunk(key []byte) (int, int) {
 	if end == -1 {
 		return start, len(key) - start
 	}
-	return start, end-start
+	return start, end - start
 }

--- a/sut/state.go
+++ b/sut/state.go
@@ -2,12 +2,13 @@ package sut
 
 import (
 	"context"
-	"github.com/v2pro/koala/envarg"
-	"github.com/v2pro/koala/recording"
-	"github.com/v2pro/plz/countlog"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/v2pro/koala/envarg"
+	"github.com/v2pro/koala/recording"
+	"github.com/v2pro/plz/countlog"
 )
 
 type SocketFD int
@@ -182,8 +183,12 @@ func gcGlobalSocks() int {
 	now := time.Now()
 	newMap := map[SocketFD]*socket{}
 	expiredSocksCount := 0
+	timeout := 5 * time.Minute
+	if envarg.GcGlobalStatusTimeout() > timeout {
+		timeout = envarg.GcGlobalStatusTimeout()
+	}
 	for fd, sock := range globalSocks {
-		if now.Sub(sock.lastAccessedAt) < time.Minute*5 {
+		if now.Sub(sock.lastAccessedAt) < envarg.GcGlobalStatusTimeout() {
 			newMap[fd] = sock
 		} else {
 			expiredSocksCount++
@@ -200,7 +205,7 @@ func gcGlobalRealThreads() int {
 	newMap := map[ThreadID]*Thread{}
 	expiredThreadsCount := 0
 	for threadId, thread := range globalThreads {
-		if now.Sub(thread.lastAccessedAt) < time.Second*5 {
+		if now.Sub(thread.lastAccessedAt) < envarg.GcGlobalStatusTimeout() {
 			newMap[threadId] = thread
 		} else {
 			shutdownThread(thread)
@@ -218,7 +223,7 @@ func gcGlobalVirtualThreads() int {
 	newMap := map[ThreadID]*Thread{}
 	expiredThreadsCount := 0
 	for threadId, thread := range globalVirtualThreads {
-		if now.Sub(thread.lastAccessedAt) < time.Second*5 {
+		if now.Sub(thread.lastAccessedAt) < envarg.GcGlobalStatusTimeout() {
 			newMap[threadId] = thread
 		} else {
 			shutdownThread(thread)


### PR DESCRIPTION
1、gc global status 超时支持环境变量设置
2、调整 outbound 读超时，以防止大数据的请求，被误识别成 mysql，导致发送 greet
3、增加部分出错的 Trace 日志，方便于排查问题，譬如输出文件重定向后的路径、输出网络包 slice content 长度、envarg 初始化值
