### PR TITLE
fixed cgo build error in mac 10.13 kernel

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,4 +30,5 @@ esac
 # build replayer by default
 export CGO_CFLAGS="-DKOALA_LIBC_NETWORK_HOOK -DKOALA_LIBC_FILE_HOOK -DKOALA_LIBC_TIME_HOOK -DKOALA_LIBC_PATH_HOOK"
 export CGO_CPPFLAGS=$CGO_CFLAGS
+export CGO_CXXFLAGS="-std=c++11 -Wno-ignored-attributes"
 go build -tags="koala_replayer" -buildmode=c-shared -o output/koala-replayer.so github.com/v2pro/koala/cmd/replayer

--- a/gateway/gw4libc/main.go
+++ b/gateway/gw4libc/main.go
@@ -1,6 +1,6 @@
+// +build !koala_recorder
 package gw4libc
 
-// #cgo !koala_recorder CXXFLAGS: --std=c++11 -Wno-ignored-attributes
 // #cgo LDFLAGS: -ldl -lm
 // #include <stddef.h>
 // #include <netinet/in.h>
@@ -14,15 +14,16 @@ package gw4libc
 // #include "init.h"
 import "C"
 import (
+	"math"
+	"net"
+	"syscall"
+	"unsafe"
+
 	"github.com/v2pro/koala/ch"
 	"github.com/v2pro/koala/envarg"
 	"github.com/v2pro/koala/gateway/gw4go"
 	"github.com/v2pro/koala/sut"
 	"github.com/v2pro/plz/countlog"
-	"math"
-	"net"
-	"syscall"
-	"unsafe"
 )
 
 func init() {


### PR DESCRIPTION
There is error when build koala_replayer on mac 10.13 version

![qq20180913-112149](https://user-images.githubusercontent.com/5964503/45465355-5ae02480-b747-11e8-9aaf-74e6683d4866.png)

Actually it can be build done through by `export CGO_CXXFLAGS_ALLOW=".*"`. But I found this way will be better. So I modified build shell and main.go under gw4libc