### PR TITLE
support cos similarity match & bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * KOALA_INBOUND_READ_TIMEOUT: a duration string, set the timeout of inbound read response from sut
 * KOALA_OUTBOUND_BYPASS_PORT: port, the port of outbound will bypass, eg replay a session with xdebug and pass xdebug remote port
 * KOALA_GC_GLOBAL_STATUS_TIMEOUT: a duration string, set the timeout of gc for koala global status, eg thread, socket
+* KOALA_REPLAYING_MATCH_STRATEGY: set outbound replaying match strategy, default use chunk match strategy, support `sim` for similarity match
 
 # Build tags
 

--- a/envarg/setup.go
+++ b/envarg/setup.go
@@ -1,8 +1,8 @@
 package envarg
 
 import (
-	"os"
 	"github.com/v2pro/plz/countlog"
+	"os"
 )
 
 func SetupLogging() {
@@ -13,7 +13,7 @@ func SetupLogging() {
 	case "HumanReadableFormat":
 		logWriter.LogFormatter = &countlog.HumanReadableFormat{
 			ContextPropertyNames: []string{"threadID", "outboundSrc"},
-			StringLengthCap:      512,
+			StringLengthCap:      1024,
 		}
 	case "CompactFormat":
 		logWriter.LogFormatter = &countlog.CompactFormat{StringLengthCap: 512}

--- a/inbound/inboud.go
+++ b/inbound/inboud.go
@@ -43,13 +43,13 @@ func handleInbound(respWriter http.ResponseWriter, req *http.Request) {
 				"stacktrace", countlog.ProvideStacktrace)
 		}
 	}()
-	countlog.Debug("event!inbound.received_request", "remoteAddr", req.RemoteAddr)
 	reqBody, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		countlog.Error("event!inbound.failed to read request", "err", err)
 		return
 	}
 	defer req.Body.Close()
+	countlog.Debug("event!inbound.received_request", "remoteAddr", req.RemoteAddr, "bodySize", len(reqBody))
 	replayingSession := replaying.NewReplayingSession()
 	err = json.Unmarshal(reqBody, replayingSession)
 	if err != nil {
@@ -61,6 +61,7 @@ func handleInbound(respWriter http.ResponseWriter, req *http.Request) {
 		countlog.Error("event!inbound.failed to assign local addresses", "err", err)
 		return
 	}
+	countlog.Info("event!inbound.assignLocalAddr", "localAddr", localAddr)
 	replaying.StoreTmp(*localAddr, replayingSession)
 	conn, err := net.DialTCP("tcp4", localAddr, envarg.SutAddr())
 	if err != nil {

--- a/outbound/outbound.go
+++ b/outbound/outbound.go
@@ -56,7 +56,7 @@ func handleOutbound(conn *net.TCPConn) {
 	}()
 	defer conn.Close()
 	tcpAddr := conn.RemoteAddr().(*net.TCPAddr)
-	countlog.Trace("event!outbound.new_conn", "addr", *tcpAddr)
+	countlog.Trace("event!outbound.new_conn", "addr", tcpAddr)
 	buf := make([]byte, 1024)
 	lastMatchedIndex := -1
 	ctx := context.WithValue(context.Background(), "outboundSrc", tcpAddr.String())
@@ -86,9 +86,7 @@ func handleOutbound(conn *net.TCPConn) {
 				}
 			}
 			countlog.Error("event!outbound.outbound can not find replaying session",
-				"ctx", ctx,
-				"addr", *tcpAddr,
-				"content", request)
+				"ctx", ctx, "addr", tcpAddr, "content", request, "protocol", protocol)
 			return
 		}
 		callOutbound := replaying.NewCallOutbound(*tcpAddr, request)
@@ -183,7 +181,8 @@ func readRequest(ctx context.Context, conn *net.TCPConn, buf []byte, isFirstPack
 		}
 		request = append(request, buf[:bytesRead]...)
 	}
-	countlog.Debug("event!outbound.request", "ctx", ctx, "content", request)
+	countlog.Debug("event!outbound.request", "ctx", ctx, "content", request,
+		"isFirstPacket", isFirstPacket, "protocol", protocol)
 	return protocol, request
 }
 

--- a/recording/action.go
+++ b/recording/action.go
@@ -71,7 +71,7 @@ type CallOutbound struct {
 	ResponseTime int64
 	Response     []byte
 	UnixAddr     net.UnixAddr
-	CSpanId		 []byte
+	CSpanId      []byte
 }
 
 func (callOutbound *CallOutbound) MarshalJSON() ([]byte, error) {
@@ -79,12 +79,12 @@ func (callOutbound *CallOutbound) MarshalJSON() ([]byte, error) {
 		CallOutbound
 		Request  json.RawMessage
 		Response json.RawMessage
-		CSpanId json.RawMessage
+		CSpanId  json.RawMessage
 	}{
 		CallOutbound: *callOutbound,
 		Request:      EncodeAnyByteArray(callOutbound.Request),
 		Response:     EncodeAnyByteArray(callOutbound.Response),
-		CSpanId:       EncodeAnyByteArray(callOutbound.CSpanId),
+		CSpanId:      EncodeAnyByteArray(callOutbound.CSpanId),
 	})
 }
 

--- a/replaying/replaying.go
+++ b/replaying/replaying.go
@@ -3,11 +3,12 @@ package replaying
 import (
 	"context"
 	"encoding/json"
-	"github.com/v2pro/koala/recording"
-	"github.com/v2pro/plz/countlog"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/v2pro/koala/recording"
+	"github.com/v2pro/plz/countlog"
 )
 
 type ReplayingSession struct {
@@ -19,7 +20,7 @@ type ReplayingSession struct {
 	MockFiles         map[string][]byte
 	TracePaths        []string
 	actionCollector   chan ReplayedAction
-	lastMaxScoreIndex int
+	lastMaxScoreIndex int // outbounds level's last matched index
 }
 
 func NewReplayingSession() *ReplayingSession {

--- a/replaying/replaying.go
+++ b/replaying/replaying.go
@@ -1,29 +1,31 @@
 package replaying
 
 import (
+	"context"
+	"encoding/json"
 	"github.com/v2pro/koala/recording"
 	"github.com/v2pro/plz/countlog"
-	"context"
 	"net"
-	"encoding/json"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 type ReplayingSession struct {
-	SessionId       string
-	CallFromInbound *recording.CallFromInbound
-	ReturnInbound   *recording.ReturnInbound
-	CallOutbounds   []*recording.CallOutbound
-	RedirectDirs    map[string]string
-	MockFiles       map[string][]byte
-	TracePaths      []string
-	actionCollector chan ReplayedAction
+	SessionId         string
+	CallFromInbound   *recording.CallFromInbound
+	ReturnInbound     *recording.ReturnInbound
+	CallOutbounds     []*recording.CallOutbound
+	RedirectDirs      map[string]string
+	MockFiles         map[string][]byte
+	TracePaths        []string
+	actionCollector   chan ReplayedAction
+	lastMaxScoreIndex int
 }
 
 func NewReplayingSession() *ReplayingSession {
 	return &ReplayingSession{
-		actionCollector: make(chan ReplayedAction, 40960),
+		actionCollector:   make(chan ReplayedAction, 40960),
+		lastMaxScoreIndex: -1,
 	}
 }
 

--- a/replaying/replaying_match.go
+++ b/replaying/replaying_match.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/v2pro/koala/envarg"
 	"github.com/v2pro/koala/recording"
 	"github.com/v2pro/plz/countlog"
 )
@@ -13,6 +14,22 @@ import (
 var expect100 = []byte("Expect: 100-continue")
 
 func (replayingSession *ReplayingSession) MatchOutboundTalk(
+	ctx context.Context, connLastMatchedIndex int, request []byte) (int, float64, *recording.CallOutbound) {
+
+	if envarg.ReplayingMatchStrategy() == replayingSimHashMatch {
+		return replayingSession.similarityMatch(ctx, connLastMatchedIndex, request)
+	} else {
+		lastMatchedIndex, mark, matchedTalk := replayingSession.chunkMatch(ctx, connLastMatchedIndex, request)
+		if matchedTalk == nil && connLastMatchedIndex >= 0 {
+			// rematch from begin and lastMatchedIndex = -1 maybe first chunk has more weight
+			// TODO: reduce cutToChunks to once, now is twice
+			return replayingSession.chunkMatch(ctx, -1, request)
+		}
+		return lastMatchedIndex, mark, matchedTalk
+	}
+}
+
+func (replayingSession *ReplayingSession) chunkMatch(
 	ctx context.Context, lastMatchedIndex int, request []byte) (int, float64, *recording.CallOutbound) {
 	unit := 16
 	chunks := cutToChunks(request, unit)
@@ -148,5 +165,5 @@ func findReadableChunk(key []byte) (int, int) {
 	if end == -1 {
 		return start, len(key) - start
 	}
-	return start, end - start
+	return start, end
 }

--- a/replaying/replaying_match.go
+++ b/replaying/replaying_match.go
@@ -57,8 +57,16 @@ func (replayingSession *ReplayingSession) MatchOutboundTalk(
 		}
 	}
 
+	// 多个 maxScore，优先从上一次成功匹配的 Index 之后开始，取第一个 maxScore，尤其是从 0 开始全部重新匹配时
+	for j, score := range scores {
+		if score == maxScore && replayingSession.lastMaxScoreIndex < j {
+			maxScoreIndex = j
+			break
+		}
+	}
 	countlog.Trace("event!replaying.talks_scored",
 		"ctx", ctx,
+		"lastMaxScoreIndex", replayingSession.lastMaxScoreIndex,
 		"lastMatchedIndex", lastMatchedIndex,
 		"maxScoreIndex", maxScoreIndex,
 		"maxScore", maxScore,
@@ -79,6 +87,9 @@ func (replayingSession *ReplayingSession) MatchOutboundTalk(
 		if mark < 0.1 {
 			return -1, 0, nil
 		}
+	}
+	if maxScoreIndex > replayingSession.lastMaxScoreIndex {
+		replayingSession.lastMaxScoreIndex = maxScoreIndex
 	}
 	return maxScoreIndex, mark, replayingSession.CallOutbounds[maxScoreIndex]
 }

--- a/replaying/replaying_similarity_match.go
+++ b/replaying/replaying_similarity_match.go
@@ -1,0 +1,107 @@
+package replaying
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/v2pro/koala/recording"
+	"github.com/v2pro/koala/replaying/similarity"
+	"github.com/v2pro/plz/countlog"
+)
+
+const replayingSimHashMatch = "sim"
+
+var globalVectors = map[string][]map[string]float64{}
+var globalVectorsMutex = &sync.Mutex{}
+
+func (replayingSession *ReplayingSession) similarityMatch(
+	ctx context.Context, connLastMatchedIndex int, request []byte) (int, float64, *recording.CallOutbound) {
+
+	maxScore := float64(0)
+	maxScoreIndex := -1
+	maxScoreCount := 0
+	scores := make([]float64, len(replayingSession.CallOutbounds))
+
+	lexer := &similarity.Lexer{}
+	reqVector := strSlice2Map(lexer.Scan(request))
+	outboundVectors := getReplayingSessionVectors(replayingSession)
+
+	for i, _ := range replayingSession.CallOutbounds {
+		scores[i] = similarity.Cosine(outboundVectors[i], reqVector)
+		if scores[i] > maxScore {
+			maxScore = scores[i]
+			maxScoreIndex = i
+			maxScoreCount = 1
+		} else if scores[i] == maxScore {
+			maxScoreCount++
+		}
+	}
+
+	if maxScoreCount > 1 {
+		fixStartIdx := getFixStartIndex(connLastMatchedIndex, replayingSession.lastMaxScoreIndex)
+		for i, score := range scores {
+			if score == maxScore && i >= fixStartIdx {
+				maxScoreIndex = i
+				break
+			}
+		}
+		// from fixStartIdx maybe can not find maxScore, so use first matched max score index
+	}
+
+	if maxScoreIndex > replayingSession.lastMaxScoreIndex {
+		replayingSession.lastMaxScoreIndex = maxScoreIndex
+	}
+
+	countlog.Trace("event!replaying.similarity_talks_scored",
+		"ctx", ctx,
+		"lastMaxScoreIndex", replayingSession.lastMaxScoreIndex,
+		"lastMatchedIndex", connLastMatchedIndex,
+		"maxScoreIndex", maxScoreIndex,
+		"maxScore", maxScore,
+		"scores", func() interface{} {
+			return fmt.Sprintf("%v", scores)
+		})
+
+	if maxScore < 0.5 {
+		return -1, 0, nil
+	}
+	return maxScoreIndex, scores[maxScoreIndex], replayingSession.CallOutbounds[maxScoreIndex]
+}
+
+func getReplayingSessionVectors(replayingSession *ReplayingSession) []map[string]float64 {
+	globalVectorsMutex.Lock()
+	defer globalVectorsMutex.Unlock()
+
+	vectors := globalVectors[replayingSession.SessionId]
+	if vectors == nil {
+		begin := time.Now()
+		lexer := similarity.Lexer{}
+		vectors = make([]map[string]float64, len(replayingSession.CallOutbounds))
+		for i, callOutbound := range replayingSession.CallOutbounds {
+			vectors[i] = strSlice2Map(lexer.Scan(callOutbound.Request))
+		}
+		globalVectors[replayingSession.SessionId] = vectors
+		countlog.Trace("event!replaying.build_min_hash", "spendTime", time.Since(begin))
+	}
+
+	return vectors
+}
+
+func strSlice2Map(str []string) map[string]float64 {
+	ret := make(map[string]float64, len(str))
+	for _, v := range str {
+		ret[v] = 1
+	}
+	return ret
+}
+
+func getFixStartIndex(connLastMatchedIndex int, lastMaxScoreIndex int) int {
+	if connLastMatchedIndex != -1 {
+		return connLastMatchedIndex
+	} else if lastMaxScoreIndex != -1 {
+		return lastMaxScoreIndex
+	}
+	return -1
+}

--- a/replaying/replaying_test.go
+++ b/replaying/replaying_test.go
@@ -1,14 +1,51 @@
 package replaying
 
 import (
-	"testing"
-	"github.com/stretchr/testify/require"
-	"github.com/v2pro/koala/recording"
-	"io/ioutil"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"encoding/base64"
+	"io/ioutil"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/v2pro/koala/recording"
+	"github.com/v2pro/koala/replaying/similarity"
+	"github.com/wilcosheh/tfidf"
 )
+
+// Lexer adapter for tfidf
+type LexerAdapter struct {
+	similarity.Lexer
+}
+
+func NewLexerAdapter() *LexerAdapter {
+	return &LexerAdapter{}
+}
+
+func (s *LexerAdapter) Seg(text string) []string {
+	return s.Scan([]byte(text))
+}
+
+func (s *LexerAdapter) Free() {
+}
+
+type IdxScore struct {
+	Index int
+	Score float64
+}
+
+type TermWeight struct {
+	Term   string
+	Weight float64
+}
+
+var escapeChars = [256]byte{
+	'a': '\a', 'b': '\b', 'f': '\f', 'n': '\n', 'r': '\r', 't': '\t', 'v': '\v', '\\': '\\', '"': '"', '\'': '\'', '?': '?',
+}
 
 func Test_match_best_score(t *testing.T) {
 	should := require.New(t)
@@ -17,7 +54,7 @@ func Test_match_best_score(t *testing.T) {
 	replayingSession := ReplayingSession{
 		CallOutbounds: []*recording.CallOutbound{talk1, talk2},
 	}
-	_, _, matched := replayingSession.MatchOutboundTalk(nil, -1, []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,})
+	_, _, matched := replayingSession.MatchOutboundTalk(nil, -1, []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8})
 	should.Equal(&talk1, matched)
 }
 
@@ -29,9 +66,9 @@ func Test_match_not_matched(t *testing.T) {
 	replayingSession := ReplayingSession{
 		CallOutbounds: []*recording.CallOutbound{talk1, talk2, talk3},
 	}
-	index, _, _ := replayingSession.MatchOutboundTalk(nil, -1, []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,})
+	index, _, _ := replayingSession.MatchOutboundTalk(nil, -1, []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8})
 	should.Equal(0, index)
-	index, _, _ = replayingSession.MatchOutboundTalk(nil, 0, []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,})
+	index, _, _ = replayingSession.MatchOutboundTalk(nil, 0, []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8})
 	should.Equal(1, index)
 }
 
@@ -58,6 +95,353 @@ func Test_bad_case(t *testing.T) {
 	should.Equal(1, index)
 }
 
+func Test_cos_without_TFIDF(t *testing.T) {
+	should := require.New(t)
+
+	orig, err := ioutil.ReadFile("koala-session-1543823956167768446-43304-original.json")
+	should.Nil(err)
+	replayingSession := NewReplayingSession()
+	err = json.Unmarshal(orig, replayingSession)
+	should.Nil(err)
+
+	replayed, err := ioutil.ReadFile("koala-session-1543823956167768446-43304-replayed.json")
+	should.Nil(err)
+	var replayedSession interface{}
+	err = json.Unmarshal(replayed, &replayedSession)
+	should.Nil(err)
+
+	begin := time.Now()
+
+	lexer := NewLexerAdapter()
+	recordOutboundsCount := len(replayingSession.CallOutbounds)
+	rawCallOutbounds := make(map[int]string)
+	recordOutbounds := make(map[int][]string, recordOutboundsCount)
+	for _, outbound := range replayingSession.CallOutbounds {
+		req := string(outbound.Request)
+		rawCallOutbounds[outbound.ActionIndex] = req
+		recordOutbounds[outbound.ActionIndex] = lexer.Scan([]byte(req))
+	}
+	fmt.Printf("Online record CallOutbound count: %d\n", recordOutboundsCount)
+
+	calledCount := 0
+	cosMatchedCount := 0
+	var scores [][]IdxScore
+	calleds := get(replayedSession, "Actions").([]interface{})
+	for _, replayedCall := range calleds {
+		called := replayedCall.(map[string]interface{})
+		actionType := called["ActionType"]
+		if actionType != "CallOutbound" {
+			continue
+		}
+		calledCount += 1
+		request := unescape(called["Request"].(string))
+		matchedIdx := int(called["MatchedActionIndex"].(float64))
+
+		maxScore := 0.0
+		maxScoreIdx := -1
+		var score []IdxScore
+		for idx, recordOutbound := range recordOutbounds {
+			online := strSlice2Map(recordOutbound)
+			test := strSlice2Map(lexer.Seg(request))
+			//online := strSlice2MapCount(recordOutbound)
+			//test := strSlice2MapCount(lexer.Seg(request))
+			sim := similarity.Cosine(online, test)
+			if sim > maxScore {
+				maxScore = sim
+				maxScoreIdx = idx
+			}
+			score = append(score, IdxScore{Index: idx, Score: sim})
+		}
+		scores = append(scores, score)
+		sort.Slice(score, func(i, j int) bool {
+			return score[i].Score > score[j].Score
+		})
+
+		fmt.Printf("Max score: %f, Second △: %f, Top 3 scores: %+v\n", maxScore, 100*(score[0].Score-score[1].Score), score[0:3])
+
+		if maxScoreIdx == matchedIdx {
+			cosMatchedCount += 1
+		} else {
+			if maxScoreIdx != -1 && request == rawCallOutbounds[maxScoreIdx] {
+				// 存在两个一模一样的请求
+				cosMatchedCount += 1
+			} else {
+				//// not match
+				//fmt.Println("Not Matched Req:\n", request)
+				//fmt.Println("Online Idx: \n", matchedIdx)
+				//fmt.Println("Test Idx: \n", maxScoreIdx)
+				//fmt.Println("Matched Req:\n", recordOutbounds[maxScoreIdx])
+				//
+				//online := f.Cal(recordOutbounds[matchedIdx])
+				//test := f.Cal(request)
+				//sim := similarity.Cosine(online, test)
+				//fmt.Println("Matched Sim:\n", sim)
+				//
+				//online = f.Cal(recordOutbounds[maxScoreIdx])
+				//test = f.Cal(request)
+				//sim = similarity.Cosine(online, test)
+				//fmt.Println("Chunk Matched Sim:\n", sim)
+			}
+		}
+	}
+	fmt.Printf("called %d, sim match count %d, spend %s\n", calledCount, cosMatchedCount, time.Since(begin))
+
+	should.Equal(calledCount, cosMatchedCount)
+}
+
+func Test_cos_TFIDF(t *testing.T) {
+	should := require.New(t)
+
+	orig, err := ioutil.ReadFile("koala-session-1543823956167768446-43304-original.json")
+	should.Nil(err)
+	replayingSession := NewReplayingSession()
+	err = json.Unmarshal(orig, replayingSession)
+	should.Nil(err)
+
+	replayed, err := ioutil.ReadFile("koala-session-1543823956167768446-43304-replayed.json")
+	should.Nil(err)
+	var replayedSession interface{}
+	err = json.Unmarshal(replayed, &replayedSession)
+	should.Nil(err)
+
+	f := tfidf.NewTokenizer(&LexerAdapter{})
+	recordOutboundsCount := len(replayingSession.CallOutbounds)
+	recordOutbounds := make(map[int]string, recordOutboundsCount)
+	for _, outbound := range replayingSession.CallOutbounds {
+		req := string(outbound.Request)
+		recordOutbounds[outbound.ActionIndex] = req
+		f.AddDocs(req)
+	}
+	fmt.Printf("Online record CallOutbound count: %d\n", recordOutboundsCount)
+
+	calledCount := 0
+	cosMatchedCount := 0
+	var scores [][]IdxScore
+	calleds := get(replayedSession, "Actions").([]interface{})
+	for _, replayedCall := range calleds {
+		called := replayedCall.(map[string]interface{})
+		actionType := called["ActionType"]
+		if actionType != "CallOutbound" {
+			continue
+		}
+		calledCount += 1
+		request := unescape(called["Request"].(string))
+		matchedIdx := int(called["MatchedActionIndex"].(float64))
+
+		maxScore := 0.0
+		maxScoreIdx := -1
+		var score []IdxScore
+		for idx, recordOutbound := range recordOutbounds {
+			online := f.Cal(recordOutbound)
+			test := f.Cal(request)
+			sim := similarity.Cosine(online, test)
+			if sim > maxScore {
+				maxScore = sim
+				maxScoreIdx = idx
+			}
+			score = append(score, IdxScore{Index: idx, Score: sim})
+		}
+		scores = append(scores, score)
+		sort.Slice(score, func(i, j int) bool {
+			return score[i].Score > score[j].Score
+		})
+
+		fmt.Printf("△: %f, Scores: %+v\n", score[0].Score-score[1].Score, score[0:3])
+
+		if maxScoreIdx == matchedIdx {
+			cosMatchedCount += 1
+		} else {
+			if maxScoreIdx != -1 && request == recordOutbounds[maxScoreIdx] {
+				cosMatchedCount += 1
+			} else {
+				//// not match
+				//fmt.Println("Not Matched Req:\n", request)
+				//fmt.Println("Online Idx: \n", matchedIdx)
+				//fmt.Println("Test Idx: \n", maxScoreIdx)
+				//fmt.Println("Matched Req:\n", recordOutbounds[maxScoreIdx])
+				//
+				//online := f.Cal(recordOutbounds[matchedIdx])
+				//test := f.Cal(request)
+				//sim := similarity.Cosine(online, test)
+				//fmt.Println("Matched Sim:\n", sim)
+				//
+				//online = f.Cal(recordOutbounds[maxScoreIdx])
+				//test = f.Cal(request)
+				//sim = similarity.Cosine(online, test)
+				//fmt.Println("Chunk Matched Sim:\n", sim)
+			}
+		}
+	}
+	fmt.Printf("called %d, sim match count %d", calledCount, cosMatchedCount)
+	should.Equal(calledCount, cosMatchedCount)
+}
+
+func Test_cos_TFIDF_limit_vector_size(t *testing.T) {
+	should := require.New(t)
+
+	orig, err := ioutil.ReadFile("koala-session-1543823956167768446-43304-original.json")
+	should.Nil(err)
+	replayingSession := NewReplayingSession()
+	err = json.Unmarshal(orig, replayingSession)
+	should.Nil(err)
+
+	replayed, err := ioutil.ReadFile("koala-session-1543823956167768446-43304-replayed.json")
+	should.Nil(err)
+	var replayedSession interface{}
+	err = json.Unmarshal(replayed, &replayedSession)
+	should.Nil(err)
+
+	f := tfidf.NewTokenizer(&LexerAdapter{})
+	recordOutboundsCount := len(replayingSession.CallOutbounds)
+	recordOutbounds := make(map[int]string, recordOutboundsCount)
+	for _, outbound := range replayingSession.CallOutbounds {
+		req := string(outbound.Request)
+		recordOutbounds[outbound.ActionIndex] = req
+		f.AddDocs(req)
+	}
+	fmt.Printf("Online record CallOutbound count: %d\n", recordOutboundsCount)
+
+	calledCount := 0
+	cosMatchedCount := 0
+	var scores [][]IdxScore
+	calleds := get(replayedSession, "Actions").([]interface{})
+	for _, replayedCall := range calleds {
+		called := replayedCall.(map[string]interface{})
+		actionType := called["ActionType"]
+		if actionType != "CallOutbound" {
+			continue
+		}
+		calledCount += 1
+		request := unescape(called["Request"].(string))
+		matchedIdx := int(called["MatchedActionIndex"].(float64))
+
+		maxScore := 0.0
+		maxScoreIdx := -1
+		var score []IdxScore
+		for idx, recordOutbound := range recordOutbounds {
+			online := resizeVector(f.Cal(recordOutbound), 30)
+			test := resizeVector(f.Cal(request), 30)
+			sim := similarity.Cosine(online, test)
+			if sim > maxScore {
+				maxScore = sim
+				maxScoreIdx = idx
+			}
+			score = append(score, IdxScore{Index: idx, Score: sim})
+		}
+		scores = append(scores, score)
+		sort.Slice(score, func(i, j int) bool {
+			return score[i].Score > score[j].Score
+		})
+
+		fmt.Printf("△: %f, Scores: %+v\n", 100*(score[0].Score-score[1].Score), score[0:3])
+
+		if maxScoreIdx == matchedIdx {
+			cosMatchedCount += 1
+		} else {
+			if maxScoreIdx != -1 && request == recordOutbounds[maxScoreIdx] {
+				cosMatchedCount += 1
+			} else {
+				//// not match
+				//fmt.Println("Not Matched Req:\n", request)
+				//fmt.Println("Online Idx: \n", matchedIdx)
+				//fmt.Println("Test Idx: \n", maxScoreIdx)
+				//fmt.Println("Matched Req:\n", recordOutbounds[maxScoreIdx])
+				//
+				//online := f.Cal(recordOutbounds[matchedIdx])
+				//test := f.Cal(request)
+				//sim := similarity.Cosine(online, test)
+				//fmt.Println("Matched Sim:\n", sim)
+				//
+				//online = f.Cal(recordOutbounds[maxScoreIdx])
+				//test = f.Cal(request)
+				//sim = similarity.Cosine(online, test)
+				//fmt.Println("Chunk Matched Sim:\n", sim)
+			}
+		}
+	}
+	fmt.Printf("called %d, sim match count %d", calledCount, cosMatchedCount)
+	should.Equal(calledCount, cosMatchedCount)
+}
+
+func Test_bad_case3(t *testing.T) {
+	should := require.New(t)
+	bytes, err := ioutil.ReadFile("/tmp/midi/session/koala-session-1537185583764907631-32020-original.json")
+	should.Nil(err)
+	origSession := NewReplayingSession()
+	err = json.Unmarshal(bytes, origSession)
+	bytes, err = ioutil.ReadFile("/tmp/midi/session/koala-session-1537185583764907631-32020-replayed.json")
+	should.Nil(err)
+	var replayedSession interface{}
+	err = json.Unmarshal(bytes, &replayedSession)
+	should.Nil(err)
+
+	req := get(replayedSession, "Actions", 263, "Request")
+	reqBytes := unescape(req.(string))
+	fmt.Println(reqBytes)
+
+	index, mark, matched := origSession.MatchOutboundTalk(nil, 22, []byte(reqBytes))
+	should.NotNil(matched)
+	fmt.Println(string(matched.Request))
+	fmt.Println(mark)
+	should.Equal(1, index)
+}
+
+func Test_chunk_match(t *testing.T) {
+	should := require.New(t)
+	bytes, err := ioutil.ReadFile("/tmp/midi/session//koala-session-1543454668151570983-12038-original.json")
+	should.Nil(err)
+	origSession := NewReplayingSession()
+	err = json.Unmarshal(bytes, origSession)
+	bytes, err = ioutil.ReadFile("/tmp/midi/session//koala-session-1543454668151570983-12038-replayed.json")
+	should.Nil(err)
+	var replayedSession interface{}
+	err = json.Unmarshal(bytes, &replayedSession)
+	should.Nil(err)
+
+	req := get(replayedSession, "Actions", 20, "Request")
+	fmt.Printf("req type:%T\n", req)
+	fmt.Println(req)
+	reqBytes := unescape(req.(string))
+	fmt.Println(reqBytes)
+
+	index, mark, matched := origSession.MatchOutboundTalk(nil, 0, []byte(reqBytes))
+	should.NotNil(matched)
+	fmt.Println(string(matched.Request))
+	fmt.Println(mark)
+	should.Equal(2, index)
+}
+
+//func Test_min_hash(t *testing.T) {
+//	should := require.New(t)
+//	bytes, err := ioutil.ReadFile("/tmp/midi/session/koala-session-1543454668151570983-12038-original.json")
+//	should.Nil(err)
+//	origSession := NewReplayingSession()
+//	err = json.Unmarshal(bytes, origSession)
+//	bytes, err = ioutil.ReadFile("/tmp/midi/session/koala-session-1543454668151570983-12038-replayed.json")
+//	should.Nil(err)
+//	var replayedSession interface{}
+//	err = json.Unmarshal(bytes, &replayedSession)
+//	should.Nil(err)
+//
+//	req := get(replayedSession, "Actions", 26, "Request")
+//	fmt.Printf("req type:%T\n", req)
+//	fmt.Println(req)
+//	reqBytes := unescape(req.(string))
+//	fmt.Println(reqBytes)
+//
+//	index, mark, matched := origSession.MatchOutboundTalk(nil, -1, []byte(reqBytes))
+//	should.NotNil(matched)
+//	fmt.Println(string(matched.Request))
+//	fmt.Println(mark)
+//	should.Equal(2, index)
+//
+//	index, mark, matched = origSession.minHashMatch(nil, -1, []byte(reqBytes))
+//	should.NotNil(matched)
+//	fmt.Println(string(matched.Request))
+//	fmt.Println(mark)
+//	should.Equal(2, index)
+//}
+
 func get(obj interface{}, keys ...interface{}) interface{} {
 	for _, key := range keys {
 		switch typedKey := key.(type) {
@@ -70,4 +454,90 @@ func get(obj interface{}, keys ...interface{}) interface{} {
 		}
 	}
 	return obj
+}
+
+func unescape(s string) string {
+	// NB: Sadly, we can't use strconv.Unquote because protoc will escape both
+	// single and double quotes, but strconv.Unquote only allows one or the
+	// other (based on actual surrounding quotes of its input argument).
+	var out []byte
+	for len(s) > 0 {
+		// regular character, or too short to be valid escape
+		if s[0] != '\\' || len(s) < 2 {
+			out = append(out, s[0])
+			s = s[1:]
+		} else if c := escapeChars[s[1]]; c != 0 {
+			// escape sequence
+			out = append(out, c)
+			s = s[2:]
+		} else if s[1] == 'x' || s[1] == 'X' {
+			// hex escape, e.g. "\x80
+			if len(s) < 4 {
+				// too short to be valid
+				out = append(out, s[:2]...)
+				s = s[2:]
+				continue
+			}
+			v, err := strconv.ParseUint(s[2:4], 16, 8)
+			if err != nil {
+				out = append(out, s[:4]...)
+			} else {
+				out = append(out, byte(v))
+			}
+			s = s[4:]
+		} else if '0' <= s[1] && s[1] <= '7' {
+			// octal escape, can vary from 1 to 3 octal digits; e.g., "\0" "\40" or "\164"
+			// so consume up to 2 more bytes or up to end-of-string
+			n := len(s[1:]) - len(strings.TrimLeft(s[1:], "01234567"))
+			if n > 3 {
+				n = 3
+			}
+			v, err := strconv.ParseUint(s[1:1+n], 8, 8)
+			if err != nil {
+				out = append(out, s[:1+n]...)
+			} else {
+				out = append(out, byte(v))
+			}
+			s = s[1+n:]
+		} else {
+			// bad escape, just propagate the slash as-is
+			out = append(out, s[0])
+			s = s[1:]
+		}
+	}
+	return string(out)
+}
+
+func strSlice2MapCount(str []string) map[string]float64 {
+	ret := make(map[string]float64, len(str))
+	for _, v := range str {
+		if _, ok := ret[v]; ok {
+			ret[v] += 1
+		} else {
+			ret[v] = 1
+		}
+	}
+	return ret
+}
+
+func resizeVector(vector map[string]float64, size int) map[string]float64 {
+	var list []TermWeight
+	for k, v := range vector {
+		list = append(list, TermWeight{Term: k, Weight: v})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Weight > list[j].Weight
+	})
+
+	i := 0
+	resize := make(map[string]float64)
+	for _, v := range list {
+		i++
+		if i > size {
+			break
+		}
+		resize[v.Term] = v.Weight
+	}
+
+	return resize
 }

--- a/replaying/similarity/cosine.go
+++ b/replaying/similarity/cosine.go
@@ -1,0 +1,25 @@
+package similarity
+
+import (
+	"math"
+)
+
+func Cosine(a, b map[string]float64) (sim float64) {
+	prod, aSquareSum, bSquareSum := 0.0, 0.0, 0.0
+
+	for aTerm, aWeight := range a {
+		if bWeight, ok := b[aTerm]; ok {
+			prod += aWeight * bWeight
+		}
+		aSquareSum += aWeight * aWeight
+	}
+	for _, bWeight := range b {
+		bSquareSum += bWeight * bWeight
+	}
+
+	if aSquareSum == 0 || bSquareSum == 0 {
+		return 0
+	}
+
+	return prod / (math.Sqrt(aSquareSum) * math.Sqrt(bSquareSum))
+}

--- a/replaying/similarity/lexer.go
+++ b/replaying/similarity/lexer.go
@@ -1,0 +1,50 @@
+package similarity
+
+import (
+	"bytes"
+	"unicode"
+)
+
+type Lexer struct {
+}
+
+func (s *Lexer) Scan(text []byte) []string {
+	var chunks []string
+	offset := 0
+
+	for {
+		strikeStart, strikeLen := findReadableChunk(text[offset:])
+		if strikeStart == -1 {
+			break
+		}
+		for i := offset; i < offset+strikeStart; i += 1 {
+			chunks = append(chunks, string(text[i:i+1])) // unreadable char
+		}
+		chunks = append(chunks, string(text[offset+strikeStart:offset+strikeStart+strikeLen])) // readable
+		offset += strikeStart + strikeLen
+	}
+
+	keyLen := len(text)
+	for i := offset; i < keyLen; i += 1 {
+		chunks = append(chunks, string(text[i:i+1])) // unreadable char
+	}
+
+	return chunks
+}
+
+func findReadableChunk(key []byte) (int, int) {
+	start := bytes.IndexFunc(key, func(r rune) bool {
+		// A-Z a-z . _
+		return unicode.IsNumber(r) || unicode.IsLetter(r) || r == 46 || r == 95
+	})
+	if start == -1 {
+		return -1, -1
+	}
+	end := bytes.IndexFunc(key[start:], func(r rune) bool {
+		return !(unicode.IsNumber(r) || unicode.IsLetter(r) || r == 46 || r == 95)
+	})
+	if end == -1 {
+		return start, len(key) - start
+	}
+	return start, end
+}

--- a/sut/thread.go
+++ b/sut/thread.go
@@ -3,17 +3,18 @@ package sut
 import (
 	"bytes"
 	"context"
-	"github.com/v2pro/koala/envarg"
-	"github.com/v2pro/koala/recording"
-	"github.com/v2pro/koala/replaying"
-	"github.com/v2pro/koala/trace"
-	"github.com/v2pro/plz/countlog"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
 	"unsafe"
+
+	"github.com/v2pro/koala/envarg"
+	"github.com/v2pro/koala/recording"
+	"github.com/v2pro/koala/replaying"
+	"github.com/v2pro/koala/trace"
+	"github.com/v2pro/plz/countlog"
 )
 
 // InboundRequestPrefix is used to recognize php-fpm FCGI_BEGIN_REQUEST packet.
@@ -192,8 +193,8 @@ func (thread *Thread) OnRecv(socketFD SocketFD, span []byte, flags RecvFlags) []
 		thread.replayingSession = replayingSession
 		countlog.Trace("event!sut.received_replaying_session",
 			"threadID", thread.threadID,
-			"replayingSession", thread.replayingSession,
-			"addr", sock.addr)
+			"replayingSessionId", thread.replayingSession.SessionId,
+			"addr", &sock.addr)
 	}
 	return span
 }


### PR DESCRIPTION
- 支持余弦相似度匹配，test 对比多种 cos 算法，譬如 tf-idf + cos、忽略权重 cos、计数权重 cos、、simhash、minhash 等，对比后效果最好的是 忽略权重 cos，第一个和第二个相似度差距明显。速度上和 chunk 差不多，一会快一点，一会慢一点，批量回放30+条记录 cos 快2-3s。准确性以发单接口为例，101个下流调用，忽略权重 cos 和 chunk 算法的结果一致，其他算法有个位数匹配失败。

- readable 切分 fix bug

- outboundBypassPorts 支持多个端口

- evgarg 统一日志相关初始化到 initLog 函数中

- 原来 chunk 算法保持不变