### PR TITLE
optimize for outboubd bypass port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * KOALA_OUTBOUND_BYPASS_PORT: port, the port of outbound will bypass, eg replay a session with xdebug and pass xdebug remote port
 * KOALA_GC_GLOBAL_STATUS_TIMEOUT: a duration string, set the timeout of gc for koala global status, eg thread, socket
 * KOALA_REPLAYING_MATCH_STRATEGY: set outbound replaying match strategy, default use chunk match strategy, support `sim` for similarity match
+* KOALA_REPLAYING_MATCH_THRESHOLD: set outbound replaying similarity match threshold
 
 # Build tags
 

--- a/envarg/envarg.go
+++ b/envarg/envarg.go
@@ -22,6 +22,7 @@ var logFormat string
 var outboundBypassPorts = make(map[int]bool, 10)
 var gcGlobalStatusTimeout = 5 * time.Second
 var replayingMatchStrategy string
+var replayingMatchThreshold = 0.7
 
 func init() {
 	initInboundAddr()
@@ -37,6 +38,7 @@ func init() {
 		"inboundReadTimeout", inboundReadTimeout,
 		"outboundBypassPorts", outboundBypassPorts,
 		"replayingMatchStrategy", replayingMatchStrategy,
+		"replayingMatchThreshold", replayingMatchThreshold,
 		"isReplaying", IsReplaying(), "isRecording", IsRecording(), "isTracing", IsTracing())
 }
 
@@ -141,6 +143,13 @@ func initReplayingMatchStrategy() {
 	if strategyStr != "" {
 		replayingMatchStrategy = strings.ToLower(strategyStr)
 	}
+	thresholdStr := GetenvFromC("KOALA_REPLAYING_MATCH_THRESHOLD")
+	if thresholdStr != "" {
+		threshold, err := strconv.ParseFloat(thresholdStr, 64)
+		if err == nil {
+			replayingMatchThreshold = threshold
+		}
+	}
 }
 
 func IsReplaying() bool {
@@ -196,6 +205,10 @@ func GcGlobalStatusTimeout() time.Duration {
 
 func ReplayingMatchStrategy() string {
 	return replayingMatchStrategy
+}
+
+func ReplayingMatchThreshold() float64 {
+	return replayingMatchThreshold
 }
 
 // GetenvFromC to make getenv work in php-fpm child process

--- a/inbound/inboud.go
+++ b/inbound/inboud.go
@@ -61,7 +61,8 @@ func handleInbound(respWriter http.ResponseWriter, req *http.Request) {
 		countlog.Error("event!inbound.failed to assign local addresses", "err", err)
 		return
 	}
-	countlog.Info("event!inbound.assignLocalAddr", "localAddr", localAddr)
+	countlog.Info("event!inbound.assignLocalAddr", "localAddr", localAddr,
+		"replayingSessionId", replayingSession.SessionId)
 	replaying.StoreTmp(*localAddr, replayingSession)
 	conn, err := net.DialTCP("tcp4", localAddr, envarg.SutAddr())
 	if err != nil {

--- a/outbound/outbound.go
+++ b/outbound/outbound.go
@@ -114,6 +114,7 @@ func handleOutbound(conn *net.TCPConn) {
 			}
 			callOutbound.MatchedMark = mark
 			if matchedTalk == nil {
+				replayingSession.CallOutbound(ctx, callOutbound)
 				countlog.Error("event!outbound.failed to find matching talk", "ctx", ctx)
 				return
 			}

--- a/replaying/replaying_similarity_match.go
+++ b/replaying/replaying_similarity_match.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/v2pro/koala/envarg"
 	"github.com/v2pro/koala/recording"
 	"github.com/v2pro/koala/replaying/similarity"
 	"github.com/v2pro/plz/countlog"
@@ -64,7 +65,7 @@ func (replayingSession *ReplayingSession) similarityMatch(
 			return fmt.Sprintf("%v", scores)
 		})
 
-	if maxScore < 0.5 {
+	if maxScore < envarg.ReplayingMatchThreshold() {
 		return -1, 0, nil
 	}
 	return maxScoreIndex, scores[maxScoreIndex], replayingSession.CallOutbounds[maxScoreIndex]
@@ -83,7 +84,7 @@ func getReplayingSessionVectors(replayingSession *ReplayingSession) []map[string
 			vectors[i] = strSlice2Map(lexer.Scan(callOutbound.Request))
 		}
 		globalVectors[replayingSession.SessionId] = vectors
-		countlog.Trace("event!replaying.build_min_hash", "spendTime", time.Since(begin))
+		countlog.Trace("event!replaying.build_vector", "spendTime", time.Since(begin))
 	}
 
 	return vectors

--- a/sut/state.go
+++ b/sut/state.go
@@ -2,6 +2,7 @@ package sut
 
 import (
 	"context"
+	"net"
 	"strconv"
 	"sync"
 	"time"
@@ -138,7 +139,7 @@ func newThread(threadID ThreadID) *Thread {
 		socks:          map[SocketFD]*socket{},
 		files:          map[FileFD]*file{},
 		lastAccessedAt: time.Now(),
-		ignoreSocks:    map[SocketFD]bool{},
+		ignoreSocks:    map[SocketFD]net.TCPAddr{},
 	}
 	if envarg.IsRecording() {
 		thread.recordingSession = recording.NewSession(int32(threadID))


### PR DESCRIPTION
1、优化 outbound bypass port，记录的 ignore fd 被 reuesed 的问题：在 accept  时候，发现被重用，就删除掉、其次在接受新请求的时候，清空数据

2、相识度算法，多少算匹配上，支持参数来决定

3、把未匹配上的内容，也加到录制里，这样就能在页面中显示新增或者未匹配上的请求